### PR TITLE
Allow tests to run under Test Explorer and from the command line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
+/.vs/
 /l3/z.l3
 /*.bak
 /loki-pl1.csproj.user
 /loki-pl1.suo
 /loki-pl1.v12.suo
+/packages/
 Backup/*
 # Build Folders
 bin

--- a/README.md
+++ b/README.md
@@ -153,4 +153,10 @@ var :a = 4 !
 Getting Started
 ---------------
 
-The current solution (.sln) file requires Visual Studio 2015.  From Solution Explorer, right click on loki-pl1, choose Properties, and enter the path to the l3 directory, since there are a couple paths that rely on it being the current path.  Starting the project should start a REPL (read-eval-print-loop), loading bootstrap.l3 and help.l3.
+The current solution (`.sln`) file requires Visual Studio 2013 or Visual
+Studio 2015 and includes the REPL (read-eval-print-loop) project
+`loki-pl1` and unit test project `loki-pl1-test`. For the REPL project,
+you should set the path to the `l3` directory from Solution Explorer:
+right-click on `loki-pl1`, choose Properties and enter the path to the
+`l3` directory in the Debug tab. Running this project should start a
+REPL, loading `bootstrap.l3` and `help.l3` from the `l3` directory.

--- a/loki-pl1-test.csproj
+++ b/loki-pl1-test.csproj
@@ -51,6 +51,7 @@
     <Compile Include="test\TEST_String.cs" />
     <Compile Include="test\TEST_TestCode.cs" />
     <Compile Include="test\TEST_Values.cs" />
+    <Compile Include="test\TestHelper.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/loki-pl1-test.csproj
+++ b/loki-pl1-test.csproj
@@ -1,0 +1,90 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{93F0FC32-4A43-480B-8C8A-74610A336EB6}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>loki3.test</RootNamespace>
+    <AssemblyName>loki-pl1-test</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="test\Properties\AssemblyInfo.cs" />
+    <Compile Include="test\TEST_ArrayFunctions.cs" />
+    <Compile Include="test\TEST_Bootstrap.cs" />
+    <Compile Include="test\TEST_Conditional.cs" />
+    <Compile Include="test\TEST_CreateFunction.cs" />
+    <Compile Include="test\TEST_EvalBuiltin.cs" />
+    <Compile Include="test\TEST_EvalLines.cs" />
+    <Compile Include="test\TEST_EvalList.cs" />
+    <Compile Include="test\TEST_EvalNode.cs" />
+    <Compile Include="test\TEST_ParseChars.cs" />
+    <Compile Include="test\TEST_ValueFunctionOverload.cs" />
+    <Compile Include="test\TEST_Logic.cs" />
+    <Compile Include="test\TEST_MapFunctions.cs" />
+    <Compile Include="test\TEST_Math.cs" />
+    <Compile Include="test\TEST_Module.cs" />
+    <Compile Include="test\TEST_ParseLine.cs" />
+    <Compile Include="test\TEST_PartialFunction.cs" />
+    <Compile Include="test\TEST_PatternChecker.cs" />
+    <Compile Include="test\TEST_String.cs" />
+    <Compile Include="test\TEST_TestCode.cs" />
+    <Compile Include="test\TEST_Values.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="test\README.md" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="loki-pl1.csproj">
+      <Project>{7142a634-0c0f-4c49-a917-95b97d3cd42f}</Project>
+      <Name>loki-pl1</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="nunit.framework, Version=3.0.5813.39031, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>packages\NUnit.3.0.1\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>if exist l3 (
+  rd /s /q l3
+)
+mkdir l3
+xcopy ..\..\l3 l3
+</PostBuildEvent>
+  </PropertyGroup>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/loki-pl1.csproj
+++ b/loki-pl1.csproj
@@ -53,11 +53,11 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=3.0.5797.27534, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL" />
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="source\AllBuiltins.cs" />
+    <Compile Include="source\AssemblyAttributes.cs" />
     <Compile Include="source\ArrayFunctions.cs" />
     <Compile Include="source\BoundFunction.cs" />
     <Compile Include="source\CreateFunction.cs" />
@@ -94,35 +94,13 @@
     <Compile Include="source\ValueArray.cs" />
     <Compile Include="source\ValueDelimiter.cs" />
     <Compile Include="source\ValueFunction.cs" />
+    <Compile Include="source\ParseChars.cs" />
     <Compile Include="source\ParseLine.cs" />
     <Compile Include="source\Program.cs" />
     <Compile Include="source\Properties\AssemblyInfo.cs" />
     <Compile Include="source\Token.cs" />
     <Compile Include="source\Value.cs" />
     <Compile Include="source\Values.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="source\ParseChars.cs" />
-    <Compile Include="test\TEST_ArrayFunctions.cs" />
-    <Compile Include="test\TEST_Bootstrap.cs" />
-    <Compile Include="test\TEST_Conditional.cs" />
-    <Compile Include="test\TEST_CreateFunction.cs" />
-    <Compile Include="test\TEST_EvalBuiltin.cs" />
-    <Compile Include="test\TEST_EvalLines.cs" />
-    <Compile Include="test\TEST_EvalList.cs" />
-    <Compile Include="test\TEST_EvalNode.cs" />
-    <Compile Include="test\TEST_ParseChars.cs" />
-    <Compile Include="test\TEST_ValueFunctionOverload.cs" />
-    <Compile Include="test\TEST_Logic.cs" />
-    <Compile Include="test\TEST_MapFunctions.cs" />
-    <Compile Include="test\TEST_Math.cs" />
-    <Compile Include="test\TEST_Module.cs" />
-    <Compile Include="test\TEST_ParseLine.cs" />
-    <Compile Include="test\TEST_PartialFunction.cs" />
-    <Compile Include="test\TEST_PatternChecker.cs" />
-    <Compile Include="test\TEST_String.cs" />
-    <Compile Include="test\TEST_TestCode.cs" />
-    <Compile Include="test\TEST_Values.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include=".gitignore" />
@@ -154,7 +132,6 @@
     <None Include="l3\wrap_tests.l3" />
     <None Include="README.md" />
     <None Include="source\README.md" />
-    <None Include="test\README.md" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">

--- a/loki-pl1.sln
+++ b/loki-pl1.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "loki-pl1", "loki-pl1.csproj", "{7142A634-0C0F-4C49-A917-95B97D3CD42F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "loki-pl1-test", "loki-pl1-test.csproj", "{93F0FC32-4A43-480B-8C8A-74610A336EB6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{7142A634-0C0F-4C49-A917-95B97D3CD42F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7142A634-0C0F-4C49-A917-95B97D3CD42F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7142A634-0C0F-4C49-A917-95B97D3CD42F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{93F0FC32-4A43-480B-8C8A-74610A336EB6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{93F0FC32-4A43-480B-8C8A-74610A336EB6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{93F0FC32-4A43-480B-8C8A-74610A336EB6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{93F0FC32-4A43-480B-8C8A-74610A336EB6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/packages.config
+++ b/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="3.0.1" targetFramework="net452" />
+</packages>

--- a/source/AssemblyAttributes.cs
+++ b/source/AssemblyAttributes.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("loki-pl1-test")]

--- a/test/Properties/AssemblyInfo.cs
+++ b/test/Properties/AssemblyInfo.cs
@@ -1,0 +1,32 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("loki-pl1-test")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("loki-pl1-test")]
+[assembly: AssemblyCopyright("")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("6c70c8d5-5eef-4903-bc4c-c43488981bd5")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/test/TEST_Bootstrap.cs
+++ b/test/TEST_Bootstrap.cs
@@ -1,5 +1,5 @@
-using System.Collections.Generic;
 using loki3.core;
+using loki3.test;
 using NUnit.Framework;
 
 namespace loki3.builtin.test
@@ -14,7 +14,7 @@ namespace loki3.builtin.test
 			{
 				m_scope = new ScopeChain();
 				AllBuiltins.RegisterAll(m_scope);
-				EvalFile.Do("l3/bootstrap.l3", m_scope);
+				TestHelper.EvalFile("l3/bootstrap.l3", m_scope);
 			}
 			return m_scope;
 		}
@@ -51,8 +51,8 @@ namespace loki3.builtin.test
 			try
 			{
 				IScope scope = new ScopeChain(GetBootstrapScope());
-				EvalFile.Do("l3/unittest.l3", scope);
-				EvalFile.Do("l3/help.l3", scope);
+				TestHelper.EvalFile("l3/unittest.l3", scope);
+				TestHelper.EvalFile("l3/help.l3", scope);
 
 				// make sure all functions have @doc
 				Value a = TestSupport.ToValue("checkDocs currentScope", scope);

--- a/test/TEST_Module.cs
+++ b/test/TEST_Module.cs
@@ -1,6 +1,7 @@
-using System.Collections.Generic;
 using loki3.core;
+using loki3.test;
 using NUnit.Framework;
+using SystemString = System.String;
 
 namespace loki3.builtin.test
 {
@@ -31,7 +32,8 @@ namespace loki3.builtin.test
 
 			{
 				int pre = scope.AsMap.Raw.Keys.Count;
-				Value value = TestSupport.ToValue("l3.loadModule { :file 'l3/module.l3' }", scope);
+				var sourceText = SystemString.Format("l3.loadModule {{ :file '{0}' }}", TestHelper.MakeTestSourcePath("l3/module.l3"));
+				Value value = TestSupport.ToValue(sourceText, scope);
 				Assert.True(value.AsBool);
 				int post = scope.AsMap.Raw.Keys.Count;
 				Assert.AreEqual(pre + 1, post);	// module has a single new var in it

--- a/test/TEST_TestCode.cs
+++ b/test/TEST_TestCode.cs
@@ -1,4 +1,5 @@
 using loki3.core;
+using loki3.test;
 using NUnit.Framework;
 
 namespace loki3.builtin.test
@@ -13,8 +14,8 @@ namespace loki3.builtin.test
 			{
 				ScopeChain scope = new ScopeChain();
 				AllBuiltins.RegisterAll(scope);
-				EvalFile.Do("l3/bootstrap.l3", scope);
-				EvalFile.Do("l3/unittest.l3", scope);
+				TestHelper.EvalFile("l3/bootstrap.l3", scope);
+				TestHelper.EvalFile("l3/unittest.l3", scope);
 
 				// use the loki3 unittest framework to test the code
 				{

--- a/test/TestHelper.cs
+++ b/test/TestHelper.cs
@@ -1,0 +1,24 @@
+﻿namespace loki3.test
+{
+    using System.IO;
+    using System.Reflection;
+    using loki3.core;
+    using CoreEvalFile = loki3.core.EvalFile;
+
+    internal static class TestHelper
+    {
+        private static readonly string s_assemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+
+        internal static void EvalFile(string fileName, IScope scope)
+        {
+            CoreEvalFile.Do(
+                MakeTestSourcePath(fileName),
+                scope);
+        }
+
+        internal static string MakeTestSourcePath(string fileName)
+        {
+            return Path.Combine(s_assemblyDir, fileName);
+        }
+    }
+}


### PR DESCRIPTION
It seems like the most reasonable way to get unit tests to handle paths to the test sources under l3 is to move the unit tests into a separate project and to perform an xcopy of the l3 sources into the test assembly's location as a post-build step. This avoids having to make any changes to how the REPL itself is deployed.

Test sources are now evaluated using the TestHelper.EvalFile method which resolves the source file path relative to the test assembly's location.

This allows the unit tests to run both from the command line and under Test Explorer in Visual Studio. This has been tested under Visual Studio 2013 and Visual Studio 2015.
